### PR TITLE
Cjc8/new operators

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - LithoOperators (0.1.1):
+  - LithoOperators (0.1.2):
     - Prelude
   - Prelude (3.0.0)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  LithoOperators: ca90994e1aa8e66eda3dcffe89095869ef5b4b66
+  LithoOperators: 3b7f496129bdf95867bd328fc80fa32b8df209ca
   Prelude: fe4cc0fd961d34edf48fe6b04d05c863449efb0a
 
 PODFILE CHECKSUM: 978fb52e184ab91794bf7459713a561a644023bd

--- a/Example/Pods/Local Podspecs/LithoOperators.podspec.json
+++ b/Example/Pods/Local Podspecs/LithoOperators.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "LithoOperators",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "summary": "LithoOperators contains some nice operators to make functional programming easier.",
   "swift_versions": [
     "4.0",
@@ -21,7 +21,7 @@
   },
   "source": {
     "git": "https://github.com/ThryvInc/LithoOperators.git",
-    "tag": "0.1.1"
+    "tag": "0.1.2"
   },
   "social_media_url": "https://twitter.com/elliot_schrock",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - LithoOperators (0.1.1):
+  - LithoOperators (0.1.2):
     - Prelude
   - Prelude (3.0.0)
 
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  LithoOperators: ca90994e1aa8e66eda3dcffe89095869ef5b4b66
+  LithoOperators: 3b7f496129bdf95867bd328fc80fa32b8df209ca
   Prelude: fe4cc0fd961d34edf48fe6b04d05c863449efb0a
 
 PODFILE CHECKSUM: 978fb52e184ab91794bf7459713a561a644023bd

--- a/Example/Pods/Target Support Files/LithoOperators/LithoOperators-Info.plist
+++ b/Example/Pods/Target Support Files/LithoOperators/LithoOperators-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.1</string>
+  <string>0.1.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Tests/HigherOrderTests.swift
+++ b/Example/Tests/HigherOrderTests.swift
@@ -71,6 +71,21 @@ class HigherOrderTests: XCTestCase {
         XCTAssertEqual(alsoCallOrder, 2)
     }
     
+    func testUnionConcat() throws {
+        var count = 0
+        var count2 = 0
+        var addToCount: (Int) -> Void = {
+            count += $0
+        }
+        let addToSecondCount: (Int) -> Void = {
+            count2 += $0
+        }
+        addToCount <>= addToSecondCount
+        addToCount(1)
+        XCTAssertTrue(count == 1)
+        XCTAssertTrue(count2 == 1)
+    }
+    
     func testUnionOperator() throws {
         let argument = "lithobyte"
         var count = 0

--- a/Example/Tests/LiftTests.swift
+++ b/Example/Tests/LiftTests.swift
@@ -28,6 +28,13 @@ class LiftTests: XCTestCase {
         XCTAssert(view.backgroundColor == .black)
     }
     
+    func testSetter() {
+        let view = UIView()
+        let setBackground = setter(\UIView.backgroundColor)
+        setBackground(view, .black)
+        XCTAssertEqual(view.backgroundColor, .black)
+    }
+    
     func testWritableInoutLift() {
         struct User {
             var name: String

--- a/Sources/LithoOperators/Classes/LithoOperators.swift
+++ b/Sources/LithoOperators/Classes/LithoOperators.swift
@@ -578,6 +578,13 @@ public func id<T>(with sideEffect: @escaping (T) -> Void) -> (T) -> (T) {
     }
 }
 
+public func setter<Root, Value>(_ kp: WritableKeyPath<Root, Value>) -> (Root, Value) -> Void {
+    return { root, val in
+        var copy = root
+        copy[keyPath: kp] = val
+    }
+}
+
 /**
  The following are from the excellent PointFree videos, and are used here and there above to
  implement some of functions.

--- a/Sources/LithoOperators/Classes/LithoOperators.swift
+++ b/Sources/LithoOperators/Classes/LithoOperators.swift
@@ -74,6 +74,14 @@ public func <><A>(f: @escaping (A) -> Void, g: @escaping (A) -> Void) -> (A) -> 
     }
 }
 
+/**
+ Operator version of `union`, although it tacks on the second function onto the first (similar to +=)
+ */
+infix operator <>=: AdditionPrecedence
+public func <>=<A>(f: inout ((A) -> Void), g: @escaping (A) -> Void) {
+    f = f <> g
+}
+
 //allows mutating A, as opposed to <>
 infix operator <~>: AdditionPrecedence
 public func <~><A>(f: @escaping (inout A) -> Void, g: @escaping (inout A) -> Void) -> (inout A) -> Void {
@@ -102,6 +110,9 @@ public func >|><A, B, C>(a: A, f: @escaping (A, B) -> C) -> (B) -> C {
 // TESTED
 public func >|><A, B, C, D>(tuple: (A, B), f: @escaping (A, B, C) -> D) -> (C) -> D {
     return { c in f(tuple.0, tuple.1, c) }
+}
+public func >|><A, B, C, D>(a: A, f: @escaping (A, B, C) -> D) -> (B, C) -> D {
+    return { b, c in f(a, b, c) }
 }
 
 /**


### PR DESCRIPTION
a couple of new operators to increase ease of use

I added to the keypath functions a function that takes a key path and returns a function that takes both a root and a value.

For example:
f = setter(^\UIView.backgroundColor)
f(view, .black) will set view's background color to black.

I also added an operator that works does what union does but similarly to the += operator. This will be useful if we have to set onViewDidLoad for an fuiviewcontroller in multiple places