### PR TITLE
added new currying operators

### DIFF
--- a/Example/Tests/CurryTests.swift
+++ b/Example/Tests/CurryTests.swift
@@ -91,4 +91,27 @@ class CurryTests: XCTestCase {
         let addTo10: (Int) -> Int = (5, 5) >|> sum3Numbers
         XCTAssert(addTo10(10) == 20)
     }
+    
+    func testFunctionalCurry() {
+        let boolToInt: (Bool) -> Int = { $0 ? 1 : 0 }
+        let addTwoNumbers: (Int, Int) -> Int = (+)
+        let addConditional: (Bool, Int) -> Int = boolToInt >|> addTwoNumbers
+        XCTAssertEqual(addConditional(true, 10), 11)
+        XCTAssertEqual(addConditional(false, 10), 10)
+        
+        let addTwoConditionals: (Bool, Bool) -> Int = boolToInt >||> addConditional
+        XCTAssertEqual(addTwoConditionals(true, true), 2)
+        XCTAssertEqual(addTwoConditionals(false, false), 0)
+        XCTAssertEqual(addTwoConditionals(false, true), 1)
+        XCTAssertEqual(addTwoConditionals(true, false), 1)
+    }
+    
+    func testVoidFunctionalCurry() {
+        let int = { 2 }
+        let addTwoNumbers: (Int, Int) -> Int = (+)
+        let addTwo: (Int) -> Int = int >|> addTwoNumbers
+        XCTAssertEqual(addTwo(1), 3)
+        let addOne = { 1 } >||> addTwoNumbers
+        XCTAssertEqual(addOne(1), 2)
+    }
 }

--- a/Example/Tests/CurryTests.swift
+++ b/Example/Tests/CurryTests.swift
@@ -95,11 +95,11 @@ class CurryTests: XCTestCase {
     func testFunctionalCurry() {
         let boolToInt: (Bool) -> Int = { $0 ? 1 : 0 }
         let addTwoNumbers: (Int, Int) -> Int = (+)
-        let addConditional: (Bool, Int) -> Int = boolToInt >|> addTwoNumbers
+        let addConditional: (Bool, Int) -> Int = boolToInt >*> addTwoNumbers
         XCTAssertEqual(addConditional(true, 10), 11)
         XCTAssertEqual(addConditional(false, 10), 10)
         
-        let addTwoConditionals: (Bool, Bool) -> Int = boolToInt >||> addConditional
+        let addTwoConditionals: (Bool, Bool) -> Int = boolToInt >**> addConditional
         XCTAssertEqual(addTwoConditionals(true, true), 2)
         XCTAssertEqual(addTwoConditionals(false, false), 0)
         XCTAssertEqual(addTwoConditionals(false, true), 1)
@@ -109,9 +109,9 @@ class CurryTests: XCTestCase {
     func testVoidFunctionalCurry() {
         let int = { 2 }
         let addTwoNumbers: (Int, Int) -> Int = (+)
-        let addTwo: (Int) -> Int = int >|> addTwoNumbers
+        let addTwo: (Int) -> Int = int >*> addTwoNumbers
         XCTAssertEqual(addTwo(1), 3)
-        let addOne = { 1 } >||> addTwoNumbers
+        let addOne = { 1 } >**> addTwoNumbers
         XCTAssertEqual(addOne(1), 2)
     }
 }

--- a/Sources/LithoOperators/Classes/LithoOperators.swift
+++ b/Sources/LithoOperators/Classes/LithoOperators.swift
@@ -167,30 +167,30 @@ public func >||||||><A, B, C, D, E, F, G>(eff: F, f: @escaping (A, B, C, D, E, F
 }
 
 /**
- These sets of operators have the same semantics as the previous, only they take two functions. The latter is the function to curry, and the former returns a value to be curried into the latter. This is the technical equivalent of using >>> (see below) to compose f with g >||> (>|||>) if we want the returned value to be curried into the third position. Using operators on operators seems a little unreadable, however, so we overload these functions.
- */
-public func >|><A, B, C>(f: @escaping () -> A, g: @escaping (A, B) -> C) -> (B) -> C {
-    return (f >>> (g >||> (>|>))) |> execute
-}
-public func >||><A, B, C>(f: @escaping () -> B, g: @escaping (A, B) -> C) -> (A) -> C {
-    return (f >>> (g >||> (>||>))) |> execute
-}
-public func >|||><A, B, C, D>(f: @escaping () -> C, g: @escaping (A, B, C) -> D) -> (A, B) -> D {
-    return (f >>> (g >||> (>|||>))) |> execute
-}
-
-/**
  These operators can also have a subsitition effect on functions, instead of a currying effect. This allows you to take a function, say g: (Int, Int) -> Int, and use another function f: (String) -> Int, and substitute f into g to make g': (String, Int) -> Int. Note that the one parameter case is achieved by the >>> operator.
  */
-public func >|><A, B, C, D>(f: @escaping (A) -> B, g: @escaping (B, C) -> D) -> (A, C) -> D {
-    return { a, c in
-        g(f(a), c)
-    }
+infix operator >*>: AdditionPrecedence
+public func >*><A, B, C, D>(f: @escaping (A) -> B, g: @escaping (B, C) -> D) -> (A, C) -> D {
+    return uncurry(f >>> curry(g))
 }
-public func >||><A, B, C, D>(f: @escaping (A) -> C, g: @escaping (B, C) -> D) -> (B, A) -> D {
-    return { b, a in
-        g(b, f(a))
-    }
+infix operator >**>: AdditionPrecedence
+public func >**><A, B, C, D>(f: @escaping (A) -> C, g: @escaping (B, C) -> D) -> (B, A) -> D {
+    return flip(uncurry(f >>> curry(flip(g))))
+}
+infix operator >***>: AdditionPrecedence
+
+
+/**
+ These sets of operators have the same semantics as the previous, only they take two functions. The latter is the function to curry, and the former returns a value to be curried into the latter. This is the technical equivalent of using >>> (see below) to compose f with g >||> (>|||>) if we want the returned value to be curried into the third position. Using operators on operators seems a little unreadable, however, so we overload these functions.
+ */
+public func >*><A, B, C>(f: @escaping () -> A, g: @escaping (A, B) -> C) -> (B) -> C {
+    return (f >>> (g >||> (>|>))) |> execute
+}
+public func >**><A, B, C>(f: @escaping () -> B, g: @escaping (A, B) -> C) -> (A) -> C {
+    return (f >>> (g >||> (>||>))) |> execute
+}
+public func >***><A, B, C, D>(f: @escaping () -> C, g: @escaping (A, B, C) -> D) -> (A, B) -> D {
+    return (f >>> (g >||> (>|||>))) |> execute
 }
 
 /**

--- a/Sources/LithoOperators/Classes/LithoOperators.swift
+++ b/Sources/LithoOperators/Classes/LithoOperators.swift
@@ -95,6 +95,9 @@ infix operator <>=: AdditionPrecedence
 public func <>=<A>(f: inout ((A) -> Void), g: @escaping (A) -> Void) {
     f = f <> g
 }
+public func <>=<A, B>(f: inout ((A, B) -> Void), g: @escaping (A, B) -> Void) {
+    f = union(f, g)
+}
 
 //allows mutating A, as opposed to <>
 infix operator <~>: AdditionPrecedence

--- a/Sources/LithoOperators/Classes/LithoOperators.swift
+++ b/Sources/LithoOperators/Classes/LithoOperators.swift
@@ -167,6 +167,33 @@ public func >||||||><A, B, C, D, E, F, G>(eff: F, f: @escaping (A, B, C, D, E, F
 }
 
 /**
+ These sets of operators have the same semantics as the previous, only they take two functions. The latter is the function to curry, and the former returns a value to be curried into the latter. This is the technical equivalent of using >>> (see below) to compose f with g >||> (>|||>) if we want the returned value to be curried into the third position. Using operators on operators seems a little unreadable, however, so we overload these functions.
+ */
+public func >|><A, B, C>(f: @escaping () -> A, g: @escaping (A, B) -> C) -> (B) -> C {
+    return (f >>> (g >||> (>|>))) |> execute
+}
+public func >||><A, B, C>(f: @escaping () -> B, g: @escaping (A, B) -> C) -> (A) -> C {
+    return (f >>> (g >||> (>||>))) |> execute
+}
+public func >|||><A, B, C, D>(f: @escaping () -> C, g: @escaping (A, B, C) -> D) -> (A, B) -> D {
+    return (f >>> (g >||> (>|||>))) |> execute
+}
+
+/**
+ These operators can also have a subsitition effect on functions, instead of a currying effect. This allows you to take a function, say g: (Int, Int) -> Int, and use another function f: (String) -> Int, and substitute f into g to make g': (String, Int) -> Int. Note that the one parameter case is achieved by the >>> operator.
+ */
+public func >|><A, B, C, D>(f: @escaping (A) -> B, g: @escaping (B, C) -> D) -> (A, C) -> D {
+    return { a, c in
+        g(f(a), c)
+    }
+}
+public func >||><A, B, C, D>(f: @escaping (A) -> C, g: @escaping (B, C) -> D) -> (B, A) -> D {
+    return { b, a in
+        g(b, f(a))
+    }
+}
+
+/**
  An operator to create a function that, given a keypath for a type, will a function that will accept
  an object of that type and return the object's property's value. So for instance,
  `^\UIViewController.view` will return a function `(UIViewController) -> UIView`
@@ -299,6 +326,19 @@ public func ignoreArgs<T, U, V, W, X, Y, Z>(_ f: @escaping () -> Z) -> (T, U, V,
 
 public func returnValue<T>(_ value: T) -> () -> T {
     return { return value }
+}
+
+/**
+ This function always executes f. Convenient when you have a function that returns a void function and you want to execute the function
+ */
+public func execute(_ f: @escaping () -> Void) {
+    f()
+}
+public func execute<T>(_ f: @escaping () -> T) -> T {
+    return f()
+}
+public func execute<A, B>(_ f: @escaping () -> (A) -> B) -> (A) -> B {
+    return f()
 }
 
 /**


### PR DESCRIPTION
The logic behind these new operators is that the currying operators have a very understandable meaning -- just plug in the left value into the first, second, or third, etc. parameter in the following function. These only work for raw values, though, and I thought it'd be cool to introduce new ways to curry functions that return parameter values into functions that take those parameters. So semantics would be exactly the same, but we are just changing the input. This would largely eliminate the need to use currying operators on currying operators, which I've noticed happening in Tapper but took me probably around an hour to get my head around.